### PR TITLE
translate: TypeScript Chapter 3, Asynchronous Work Chapter 6, 8

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -19,7 +19,7 @@
 
 - [Introduction to TypeScript](docs/typescript/introduction-to-typescript.md)
 - [Running TypeScript code using transpilation](docs/typescript/running-typescript-code-using-transpilation.md)
-- [Running TypeScript with a runner](docs/typescript/running-typescript-with-a-runner.md)
+- [runner를 사용하여 TypeScript 실행하기](docs/typescript/running-typescript-with-a-runner.md)
 - [Running TypeScript Natively](docs/typescript/running-typescript-natively.md)
 
 ## Asynchronous Work
@@ -29,9 +29,9 @@
 - [JavaScript Asynchronous Programming and Callbacks](docs/asynchronous-work/javascript-asynchronous-programming-and-callbacks.md)
 - [Discover JavaScript Timers](docs/asynchronous-work/discover-javascript-timers.md)
 - [The Node.js Event Loop](docs/asynchronous-work/the-nodejs-event-loop.md)
-- [The Node.js Event Emitter](docs/asynchronous-work/the-nodejs-event-emitter.md)
+- [Node.js의 Event emitter](docs/asynchronous-work/the-nodejs-event-emitter.md)
 - [Understanding process.nextTick()](docs/asynchronous-work/understanding-process-nexttick.md)
-- [Understanding setImmediate()](docs/asynchronous-work/understanding-setimmediate.md)
+- [setImmediate() 이해하기](docs/asynchronous-work/understanding-setimmediate.md)
 - [Don't Block the Event Loop](docs/asynchronous-work/dont-block-the-event-loop.md)
 
 ## Manipulating Files

--- a/docs/asynchronous-work/the-nodejs-event-emitter.md
+++ b/docs/asynchronous-work/the-nodejs-event-emitter.md
@@ -1,18 +1,21 @@
 ---
-title: The Node.js Event emitter
+title: Node.js의 Event emitter
 layout: learn
 authors: flaviocopes, MylesBorins, fhemberger, LaRuaNa, ahmadawais, ovflowd
 ---
 
+> ❗️ _번역 날짜: 2024년 12월 17일_ <br />
+> 공식 문서 원문은 아래를 참고하세요.<br /> > [The Node.js Event emitter](https://nodejs.org/en/learn/asynchronous-work/the-nodejs-event-emitter#the-nodejs-event-emitter)
+
 # The Node.js Event emitter
 
-If you worked with JavaScript in the browser, you know how much of the interaction of the user is handled through events: mouse clicks, keyboard button presses, reacting to mouse movements, and so on.
+브라우저에서 JavaScript를 사용해 봤다면, 마우스 클릭, 키보드 버튼 입력, 마우스 움직임에 반응하기 등 정말 많은 상호작용이 이벤트를 통해 처리된다는 것을 알고 있을 것입니다.
 
-On the backend side, Node.js offers us the option to build a similar system using the [`events` module](https://nodejs.org/api/events.html).
+백엔드에서는 Node.js가 [`events` module](https://nodejs.org/api/events.html) 을 통해 유사한 시스템을 구축할 수 있는 옵션을 제공합니다.
 
-This module, in particular, offers the `EventEmitter` class, which we'll use to handle our events.
+이 모듈에서 특히 중요한 것은 이벤트를 처리하기 위한 `EventEmitter` 클래스입니다.
 
-You initialize that using
+다음과 같이 초기화할 수 있습니다.
 
 ```cjs
 const EventEmitter = require('node:events');
@@ -26,12 +29,12 @@ import EventEmitter from 'node:events';
 const eventEmitter = new EventEmitter();
 ```
 
-This object exposes, among many others, the `on` and `emit` methods.
+이 객체는 여러 메서드를 노출하며, 그중에서 중요한 `on` 과 `emit` 메서드가 있습니다.
 
-- `emit` is used to trigger an event
-- `on` is used to add a callback function that's going to be executed when the event is triggered
+- `emit`: 이벤트를 **발생**시키는 데 사용됩니다.
+- `on`: 이벤트가 발생했을 때 실행할 **콜백 함수**를 추가하는 데 사용됩니다.
 
-For example, let's create a `start` event, and as a matter of providing a sample, we react to that by just logging to the console:
+예를 들어, `start` 라는 이벤트를 생성하고, 콘솔에 출력함으로써 이벤트에 반응해봅시다.
 
 ```js
 eventEmitter.on('start', () => {
@@ -39,15 +42,16 @@ eventEmitter.on('start', () => {
 });
 ```
 
-When we run
+이후 다음을 실행하면
 
 ```js
 eventEmitter.emit('start');
 ```
 
+이벤트 핸들러 함수가 트리거되며 콘솔에 로그가 출력됩니다.
 the event handler function is triggered, and we get the console log.
 
-You can pass arguments to the event handler by passing them as additional arguments to `emit()`:
+`emit()` 메서드에 추가적인 인자를 전달하여 이벤트 핸들러에 값을 넘길 수 있습니다.
 
 ```js
 eventEmitter.on('start', (number) => {
@@ -57,7 +61,7 @@ eventEmitter.on('start', (number) => {
 eventEmitter.emit('start', 23);
 ```
 
-Multiple arguments:
+여러 개의 인자 전달하기
 
 ```js
 eventEmitter.on('start', (start, end) => {
@@ -67,10 +71,10 @@ eventEmitter.on('start', (start, end) => {
 eventEmitter.emit('start', 1, 100);
 ```
 
-The EventEmitter object also exposes several other methods to interact with events, like
+EventEmitter 객체는 이벤트에 상호작용할 수 있는 몇 가지 다른 메서드도 제공합니다:
 
-- `once()`: add a one-time listener
-- `removeListener()` / `off()`: remove an event listener from an event
-- `removeAllListeners()`: remove all listeners for an event
+- `once()`: 한 번만 실행되는(one-time) 이벤트 리스너를 추가합니다.
+- `removeListener()` / `off()`: 이벤트에서 특정 리스너를 제거합니다.
+- `removeAllListeners()`: 특정 이벤트에 등록된 모든 리스너를 제거합니다.
 
-You can read more about these methods in the [official documentation](https://nodejs.org/api/events.html).
+이 메서드들에 대한 더 자세한 내용은 [공식 문서](https://nodejs.org/api/events.html) 에서 확인할 수 있습니다.

--- a/docs/asynchronous-work/the-nodejs-event-emitter.md
+++ b/docs/asynchronous-work/the-nodejs-event-emitter.md
@@ -5,9 +5,10 @@ authors: flaviocopes, MylesBorins, fhemberger, LaRuaNa, ahmadawais, ovflowd
 ---
 
 > ❗️ _번역 날짜: 2024년 12월 17일_ <br />
-> 공식 문서 원문은 아래를 참고하세요.<br /> > [The Node.js Event emitter](https://nodejs.org/en/learn/asynchronous-work/the-nodejs-event-emitter#the-nodejs-event-emitter)
+> 공식 문서 원문은 아래를 참고하세요.<br />
+> [The Node.js Event emitter](https://nodejs.org/en/learn/asynchronous-work/the-nodejs-event-emitter#the-nodejs-event-emitter)
 
-# The Node.js Event emitter
+# Node.js의 Event emitter
 
 브라우저에서 JavaScript를 사용해 봤다면, 마우스 클릭, 키보드 버튼 입력, 마우스 움직임에 반응하기 등 정말 많은 상호작용이 이벤트를 통해 처리된다는 것을 알고 있을 것입니다.
 

--- a/docs/asynchronous-work/understanding-setimmediate.md
+++ b/docs/asynchronous-work/understanding-setimmediate.md
@@ -1,12 +1,11 @@
 ---
-title: 이해하기 setImmediate()
+title: setImmediate() 이해하기
 layout: learn
 authors: flaviocopes, MylesBorins, LaRuaNa, ahmadawais, clean99, ovflowd
 ---
 
 > ❗️ _번역 날짜: 2024년 12월 17일_ <br />
-> 공식 문서 원문은 아래를 참고하세요.<br />
-> [Understanding setImmediate()](https://nodejs.org/en/learn/asynchronous-work/understanding-setimmediate#understanding-setimmediate)
+> 공식 문서 원문은 아래를 참고하세요.<br /> > [Understanding setImmediate()](https://nodejs.org/en/learn/asynchronous-work/understanding-setimmediate#understanding-setimmediate)
 
 # setImmediate() 이해하기
 

--- a/docs/asynchronous-work/understanding-setimmediate.md
+++ b/docs/asynchronous-work/understanding-setimmediate.md
@@ -5,7 +5,8 @@ authors: flaviocopes, MylesBorins, LaRuaNa, ahmadawais, clean99, ovflowd
 ---
 
 > ❗️ _번역 날짜: 2024년 12월 17일_ <br />
-> 공식 문서 원문은 아래를 참고하세요.<br /> > [Understanding setImmediate()](https://nodejs.org/en/learn/asynchronous-work/understanding-setimmediate#understanding-setimmediate)
+> 공식 문서 원문은 아래를 참고하세요.<br />
+> [Understanding setImmediate()](https://nodejs.org/en/learn/asynchronous-work/understanding-setimmediate#understanding-setimmediate)
 
 # setImmediate() 이해하기
 

--- a/docs/asynchronous-work/understanding-setimmediate.md
+++ b/docs/asynchronous-work/understanding-setimmediate.md
@@ -1,12 +1,15 @@
 ---
-title: Understanding setImmediate()
+title: 이해하기 setImmediate()
 layout: learn
 authors: flaviocopes, MylesBorins, LaRuaNa, ahmadawais, clean99, ovflowd
 ---
 
-# Understanding setImmediate()
+> ❗️ _번역 날짜: 2024년 12월 17일_ <br />
+> 공식 문서 원문은 아래를 참고하세요.<br /> > [Understanding setImmediate()](https://nodejs.org/en/learn/asynchronous-work/understanding-setimmediate#understanding-setimmediate)
 
-When you want to execute some piece of code asynchronously, but as soon as possible, one option is to use the `setImmediate()` function provided by Node.js:
+# setImmediate() 이해하기
+
+코드를 비동기적으로 실행하지만 가능한 한 빠르게 실행하고 싶을 때, Node.js에서 제공하는 `setImmediate()` 함수를 사용할 수 있습니다:
 
 ```js
 setImmediate(() => {
@@ -14,19 +17,23 @@ setImmediate(() => {
 });
 ```
 
-Any function passed as the setImmediate() argument is a callback that's executed in the next iteration of the event loop.
+setImmediate() 의 인자로 전달된 함수는 이벤트 루프의 다음 반복(iteration)에 실행되는 **콜백** (**callback**)입니다.
 
-How is `setImmediate()` different from `setTimeout(() => {}, 0)` (passing a 0ms timeout), and from `process.nextTick()` and `Promise.then()`?
+`setImmediate()` 과 `setTimeout(() => {}, 0)` (0초의 타임아웃을 넘기는) 는 무엇이 다르며, `process.nextTick()` 과 `Promise.then()` 는 무엇이 다를까요?
 
-A function passed to `process.nextTick()` is going to be executed on the current iteration of the event loop, after the current operation ends. This means it will always execute before `setTimeout` and `setImmediate`.
+`process.nextTick()` 에 전달된 함수는 이벤트 루프의 현재 작업 이후 **현재 반복(iteration)** 이 끝난 직후 실행됩니다.
 
-A `setTimeout()` callback with a 0ms delay is very similar to `setImmediate()`. The execution order will depend on various factors, but they will be both run in the next iteration of the event loop.
+즉, 항상 `setTimeout` 이나 `setImmediate`.보다 먼저 실행됩니다.
 
-A `process.nextTick` callback is added to `process.nextTick queue`. A `Promise.then()` callback is added to `promises microtask queue`. A `setTimeout`, `setImmediate` callback is added to `macrotask queue`.
+`setTimeout()` 0ms의 지연시간을 가진 콜백은 `setImmediate()` 와 매우 유사합니다. The 실행 순서는 여러 요인에 따라 달라질 수 있지만, 두 콜백 모두 이벤트 루프의 다음 반복에 실행됩니다.
 
-Event loop executes tasks in `process.nextTick queue` first, and then executes `promises microtask queue`, and then executes `macrotask queue`.
+- `process.nextTick` 콜백은 `process.nextTick queue` 에 추가됩니다.
+- `Promise.then()` 콜백은 `promises microtask queue`에 추가됩니다.
+- `setTimeout`,`setImmediate` 콜백은 `macrotask queue` 에 추가됩니다.
 
-Here is an example to show the order between `setImmediate()`, `process.nextTick()` and `Promise.then()`:
+이벤트 루프는 `process.nextTick queue` 의 작업을 먼저 수행하고, `promises microtask queue`, `macrotask queue` 의 순서로 작업을 수행합니다.
+
+아래 코드는 `setImmediate()`, `process.nextTick()` 그리고 `Promise.then()` 간의 실행 순서를 보여줍니다.
 
 ```js
 const baz = () => console.log('baz');
@@ -50,12 +57,12 @@ start();
 // start foo bar zoo baz
 ```
 
-This code will first call `start()`, then call `foo()` in `process.nextTick queue`. After that, it will handle `promises microtask queue`, which prints `bar` and adds `zoo()` in `process.nextTick queue` at the same time. Then it will call `zoo()` which has just been added. In the end, the `baz()` in `macrotask queue` is called.
+이 코드는 `start()` 를 가장 먼저 호출할 것이고, 이후 `process.nextTick queue` 의 `foo()` 를 호출할 것입니다. 그런 다음 `promises microtask queue` 의 `bar` 를 출력하고 동시에 `process.nextTick queue` 에 `zoo()` 를 추가합니다. 이제 방금 추가된 `zoo()` 를 호출하고 `macrotask queue` 의 `baz()` 가 마지막으로 호출됩니다.
 
-The principle aforementioned holds true in CommonJS cases, but keep in mind in ES Modules, e.g. `mjs` files, the execution order will be different:
+위의 원칙은 CommonJS 환경에서 유효하지만, `mjs` 파일과 같은 ES Modules 환경에서는 실행 순서가 다를 수 있음을 유념해야합니다.
 
 ```js
 // start bar foo zoo baz
 ```
 
-This is because the ES Module being loaded is wrapped as an asynchronous operation, and thus the entire script is actually already in the `promises microtask queue`. So when the promise is immediately resolved, its callback is appended to the `microtask` queue. Node.js will attempt to clear the queue until moving to any other queue, and hence you will see it outputs `bar` first.
+이는 로드되고있는 ES Module이 비동기적 작업으로 감싸져 실행되기 때문입니다. 따라서 전체 스크립트가 이미 `promises microtask queue` 에 존재하게 됩니다. 그래서 Promise가 즉시 해결(resolve) 되면 해당 콜백이 `microtask` 에 추가됩니다. Node.js는 `microtask` 큐를 비울 때까지 다른 큐로 이동하지 않으므로, `bar` 가 먼저 출력되는 것입니다.

--- a/docs/typescript/running-typescript-with-a-runner.md
+++ b/docs/typescript/running-typescript-with-a-runner.md
@@ -6,8 +6,8 @@ authors: AugustinMauroy
 
 # runner를 사용하여 TypeScript 실행하기
 
-> ❗️ _번역 날짜: 2024년 12월 17일_ <br>
-> 공식 문서 원문은 아래를 참고하세요.<br> > [Running TypeScript with a runnery](https://nodejs.org/en/learn/typescript/run#running-typescript-with-a-runner)
+> ❗️ _번역 날짜: 2024년 12월 17일_ <br />
+> 공식 문서 원문은 아래를 참고하세요.<br /> > [Running TypeScript with a runner](https://nodejs.org/en/learn/typescript/run#running-typescript-with-a-runner)
 
 이전 글에서는 **트랜스파일링** (**transpilation**)을 사용해 TypeScript 코드를 실행하는 방법을 알아봤습니다. 이번 글에서는 어떻게 runner를 사용하여 TypeScript 코드를 실행하는지 배워보겠습니다.
 

--- a/docs/typescript/running-typescript-with-a-runner.md
+++ b/docs/typescript/running-typescript-with-a-runner.md
@@ -1,48 +1,51 @@
 ---
-title: Running TypeScript with a runner
+title: runner로 TypeScript 실행하기
 layout: learn
 authors: AugustinMauroy
 ---
 
-# Running TypeScript with a runner
+# runner를 사용하여 TypeScript 실행하기
 
-In the previous article, we learned how to run TypeScript code using transpilation. In this article, we will learn how to run TypeScript code using a runner.
+> ❗️ _번역 날짜: 2024년 12월 17일_ <br>
+> 공식 문서 원문은 아래를 참고하세요.<br> > [Running TypeScript with a runnery](https://nodejs.org/en/learn/typescript/run#running-typescript-with-a-runner)
 
-## Running TypeScript code with `ts-node`
+이전 글에서는 **트랜스파일링** (**transpilation**)을 사용해 TypeScript 코드를 실행하는 방법을 알아봤습니다. 이번 글에서는 어떻게 runner를 사용하여 TypeScript 코드를 실행하는지 배워보겠습니다.
 
-[ts-node](https://typestrong.org/ts-node/) is a TypeScript execution environment for Node.js. It allows you to run TypeScript code directly in Node.js without the need to compile it first. Note, however, that it does not type check your code. So we recommend to type check your code first with `tsc` and then run it with `ts-node` before shipping it.
+## TypeScript 코드를 `ts-node` 를 이용해 실행하기
 
-To use `ts-node`, you need to install it first:
+[ts-node](https://typestrong.org/ts-node/) 는 Node.js용 TypeScript 실행환경입니다. 이를 사용하면 코드를 먼저 컴파일하지 않고도 TypeScript 코드를 직접 Node.js에서 실행할 수 있습니다. 하지만 주의할 점은 `ts-node` 는 코드의 타입 체크를 수행하지 않는다는 것입니다. 따라서 코드를 배포하기 전에 `tsc` 를 사용해 타입 체크를 먼저 수행하고 `ts-node` 로 실행하는 것을 권장합니다.
+
+**ts-node**를 사용하기 위해 먼저 이를 설치해야 합니다.
 
 ```bash
 npm i -D ts-node
 ```
 
-Then you can run your TypeScript code like this:
+그리고 아래와 같이 TypeScript코드를 실행할 수 있습니다.
 
 ```bash
 npx ts-node example.ts
 ```
 
-## Running TypeScript code with `tsx`
+## `tsx` 로 TypeScript 코드 실행하기
 
-[tsx](https://tsx.is/) is another TypeScript execution environment for Node.js. It allows you to run TypeScript code directly in Node.js without the need to compile it first. Note, however, that it does not type check your code. So we recommend to type check your code first with `tsc` and then run it with `tsx` before shipping it.
+[tsx](https://tsx.is/) 는 또 다른 Node.js용 TypeScript 실행 환경입니다. `tsx` 를 사용하면 코드를 먼저 컴파일하지 않고도 TypeScript 코드를 직접 Node.js에서 실행할 수 있습니다. 하지만 tsx 역시 코드의 타입 체크를 수행하지 않습니다. 따라서 `tsc` 를 사용해 타입 체크를 먼저 수행하고 `tsx` 로 실행하는 것을 권장합니다.
 
-To use `tsx`, you need to install it first:
+`tsx` 를 사용하기 위해, 이를 먼저 이를 설치해야 합니다.
 
 ```bash
 npm i -D tsx
 ```
 
-Then you can run your TypeScript code like this:
+그리고 아래와 같이 TypeScript코드를 실행할 수 있습니다.
 
 ```bash
 npx tsx example.ts
 ```
 
-### Registering `tsx` via `node`
+## `node` 에서 `tsx` 등록하기
 
-If you want to use `tsx` via `node`, you can register `tsx` via `--import`:
+만약 `node` 에서 `tsx` 를 사용하고싶다면 `--import` 를 통해 `tsx` 를 등록할 수 있습니다.
 
 ```bash
 node --import=tsx example.ts

--- a/docs/typescript/running-typescript-with-a-runner.md
+++ b/docs/typescript/running-typescript-with-a-runner.md
@@ -7,7 +7,8 @@ authors: AugustinMauroy
 # runner를 사용하여 TypeScript 실행하기
 
 > ❗️ _번역 날짜: 2024년 12월 17일_ <br />
-> 공식 문서 원문은 아래를 참고하세요.<br /> > [Running TypeScript with a runner](https://nodejs.org/en/learn/typescript/run#running-typescript-with-a-runner)
+> 공식 문서 원문은 아래를 참고하세요.<br />
+> [Running TypeScript with a runner](https://nodejs.org/en/learn/typescript/run#running-typescript-with-a-runner)
 
 이전 글에서는 **트랜스파일링** (**transpilation**)을 사용해 TypeScript 코드를 실행하는 방법을 알아봤습니다. 이번 글에서는 어떻게 runner를 사용하여 TypeScript 코드를 실행하는지 배워보겠습니다.
 


### PR DESCRIPTION
## 작업 내용
### TypeScript 챕터
 - Chapter 3 : running-typescript-with-a-runner -> runner를 사용하여 TypeScript 실행하기

### asynchronous-work 챕터
- Chapter 6 : the-nodejs-event-emitter -> Node.js의 Event emitter
- Chapter 8 : understanding-setimmediate -> 

## 특이 사항
 - `tsx` 문법을 사용할 때 앞 뒤 띄어쓰기를 넣나요?
 - 원문의 구조를 상당 부분 유지하는지, 아니면 한국어에 맞춰서 조금 변형된 세부목차를 주는 게 나을 지 고민입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 문서 제목이 영어에서 한국어로 번역되었습니다: "Running TypeScript with a runner" → "runner로 TypeScript 실행하기", "The Node.js Event Emitter" → "Node.js의 Event emitter", "Understanding setImmediate()" → "setImmediate() 이해하기".
  
- **문서화**
	- "TypeScript", "Asynchronous Work" 섹션의 문서가 완전히 한국어로 번역되었습니다.
	- 번역 날짜와 원본 영어 문서 링크가 추가되었습니다.
	- 문서 내용 및 예제가 한국어로 번역되어 제공되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->